### PR TITLE
ci: Check if rjags can be loaded

### DIFF
--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -3,8 +3,13 @@ name: 'Custom steps to run after R packages are installed'
 runs:
   using: "composite"
   steps:
-    - name: Check rjags on macOS
+    - name: Install rjags fro source on macOS
       if: runner.os == 'macOS'
+      run: |
+        install.packages("rjags", type = "source")
+      shell: Rscript {0}
+
+    - name: Check rjags
       run: |
         library(rjags)
       shell: Rscript {0}

--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -1,0 +1,10 @@
+name: 'Custom steps to run after R packages are installed'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check rjags on macOS
+      if: runner.os == 'macOS'
+      run: |
+        library(rjags)
+      shell: Rscript {0}


### PR DESCRIPTION
This will fail CI/CD on macOS at a stage before building the vignette. Fixing the rjags installation will then also likely fix CI/CD.