### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,5 @@
 ^_pkgdown\.yml$
 ^README\.Rmd$
 ^\.ccache$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/analyse.R
+++ b/R/analyse.R
@@ -1,32 +1,69 @@
-jmb_analyse_chain <- function(inits, loaded, data, monitor, niters, ngens, nthin, quiet) {
-  capture_output <- if (quiet) function(x) suppressWarnings(capture.output(x)) else eval
+jmb_analyse_chain <- function(
+  inits,
+  loaded,
+  data,
+  monitor,
+  niters,
+  ngens,
+  nthin,
+  quiet
+) {
+  capture_output <- if (quiet) {
+    function(x) suppressWarnings(capture.output(x))
+  } else {
+    eval
+  }
 
   capture_output(
-    jags_model <- rjags::jags.model(loaded, data, inits = inits, n.adapt = 0, quiet = quiet)
+    jags_model <- rjags::jags.model(
+      loaded,
+      data,
+      inits = inits,
+      n.adapt = 0,
+      quiet = quiet
+    )
   )
 
   niters <- niters * nthin
-  adapted <- rjags::adapt(jags_model,
+  adapted <- rjags::adapt(
+    jags_model,
     n.iter = floor(niters / 2),
-    progress.bar = "none", end.adaptation = TRUE
+    progress.bar = "none",
+    end.adaptation = TRUE
   )
 
-  if (!adapted) warning("incomplete adaptation")
+  if (!adapted) {
+    warning("incomplete adaptation")
+  }
 
   update(jags_model, n.iter = floor(niters / 2), progress.bar = "none")
 
   monitor <- monitor[monitor %in% stats::variable.names(jags_model)]
 
   jags_samples <- rjags::jags.samples(
-    model = jags_model, variable.names = monitor,
-    n.iter = niters, thin = nthin, progress.bar = "none"
+    model = jags_model,
+    variable.names = monitor,
+    n.iter = niters,
+    thin = nthin,
+    progress.bar = "none"
   )
 
   list(jags_model = jags_model, jags_samples = jags_samples)
 }
 
 #' @export
-analyse1.jmb_model <- function(model, data, loaded, nchains, niters, nthin, quiet, glance, parallel, ...) {
+analyse1.jmb_model <- function(
+  model,
+  data,
+  loaded,
+  nchains,
+  niters,
+  nthin,
+  quiet,
+  glance,
+  parallel,
+  ...
+) {
   timer <- timer::Timer$new()
   timer$start()
 
@@ -39,7 +76,8 @@ analyse1.jmb_model <- function(model, data, loaded, nchains, niters, nthin, quie
   monitor <- embr::monitor(model)
   monitor <- monitor[!monitor %in% names(data)]
 
-  jags_chains <- llply(inits,
+  jags_chains <- llply(
+    inits,
     .fun = jmb_analyse_chain,
     .parallel = parallel,
     loaded = loaded,
@@ -51,10 +89,13 @@ analyse1.jmb_model <- function(model, data, loaded, nchains, niters, nthin, quie
   )
 
   mcmc <- llply(jags_chains, function(x) x$jags_samples)
-  mcmc <- lapply(mcmc, function(x) mcmcr::as.mcmcr(lapply(x, mcmcr::as.mcmcarray)))
+  mcmc <- lapply(mcmc, function(x) {
+    mcmcr::as.mcmcr(lapply(x, mcmcr::as.mcmcarray))
+  })
   mcmc <- Reduce(mcmcr::bind_chains, mcmc)
 
-  obj <- c(obj,
+  obj <- c(
+    obj,
     inits = list(inits),
     jags_chains = list(jags_chains),
     mcmcr = list(mcmc),
@@ -64,7 +105,9 @@ analyse1.jmb_model <- function(model, data, loaded, nchains, niters, nthin, quie
   obj$duration <- timer$elapsed()
   class(obj) <- c("jmb_analysis", "mb_analysis")
 
-  if (glance) print(glance(obj))
+  if (glance) {
+    print(glance(obj))
+  }
 
   obj
 }

--- a/R/sd-priors-by.R
+++ b/R/sd-priors-by.R
@@ -1,16 +1,27 @@
 #' @export
 sd_priors_by.jmb_code <- function(
-    x, by = 10, distributions = c("normal", "lognormal", "t"), ...) {
+  x,
+  by = 10,
+  distributions = c("normal", "lognormal", "t"),
+  ...
+) {
   chk_number(by)
   chk_range(by, c(0.001, 1000))
   chk_unused(...)
 
   chk_s3_class(distributions, "character")
   chk_unique(distributions)
-  chk_subset(distributions, c(
-    "laplace", "logistic", "lognormal",
-    "normal", "t", "nt"
-  ))
+  chk_subset(
+    distributions,
+    c(
+      "laplace",
+      "logistic",
+      "lognormal",
+      "normal",
+      "t",
+      "nt"
+    )
+  )
 
   if (!length(distributions)) {
     wrn("No prior distributions included.")

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/scripts/build.R
+++ b/scripts/build.R
@@ -9,4 +9,3 @@ rmarkdown::render("README.Rmd", output_format = "md_document")
 pkgdown::build_site()
 
 devtools::check()
-

--- a/tests/testthat/test-code.R
+++ b/tests/testthat/test-code.R
@@ -27,7 +27,6 @@ test_that("analyse", {
   }
 }"
 
-
   code <- mb_code(template)
 
   expect_identical(class(code), c("jmb_code", "mb_code"))
@@ -38,7 +37,11 @@ test_that("analyse", {
   expect_error(pars(code, param_type = "primary"))
   expect_error(pars(code, scalar = TRUE))
 
-  code10 <- sd_priors_by(code, 10, distributions = c("logistic", "normal", "lognormal", "t"))
+  code10 <- sd_priors_by(
+    code,
+    10,
+    distributions = c("logistic", "normal", "lognormal", "t")
+  )
   expect_true(is.jmb_code(code10))
   expect_identical(pars(code10), pars(code))
   expect_identical(

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -35,11 +35,14 @@ test_that("analyse", {
   model <- model(
     code = template,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor")),
     new_expr = new_expr
   )

--- a/tests/testthat/test-zzz-analyse.R
+++ b/tests/testthat/test-zzz-analyse.R
@@ -42,16 +42,21 @@ test_that("analyse character vector", {
   model <- model(
     code = jags_template,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor")),
     new_expr = new_expr
   )
 
-  expect_output(expect_warning(expect_warning(analysis <- analyse(model, data = data))))
+  expect_output(expect_warning(expect_warning(
+    analysis <- analyse(model, data = data)
+  )))
 
   expect_equal(as.data.frame(data_set(analysis)), data)
   data2 <- data_set(analysis, marginalize_random_effects = TRUE)
@@ -78,72 +83,142 @@ test_that("analyse character vector", {
   expect_identical(niters(analysis), 10L)
   expect_identical(ngens(analysis), 40L)
 
-
-  expect_identical(pars(analysis, "fixed"), sort(c("bHabitatQuality", "bIntercept", "bYear", "log_sDensity", "log_sSiteYear")))
+  expect_identical(
+    pars(analysis, "fixed"),
+    sort(c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    ))
+  )
   expect_identical(pars(analysis, "random"), "bSiteYear")
   expect_identical(pars(analysis, "derived"), "eDensity")
   expect_identical(
     pars(analysis, "primary"),
-    c("bHabitatQuality", "bIntercept", "bSiteYear", "bYear", "log_sDensity", "log_sSiteYear")
+    c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bSiteYear",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    )
   )
   expect_identical(
     pars(analysis),
-    c("bHabitatQuality", "bIntercept", "bSiteYear", "bYear", "eDensity", "log_sDensity", "log_sSiteYear")
+    c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bSiteYear",
+      "bYear",
+      "eDensity",
+      "log_sDensity",
+      "log_sSiteYear"
+    )
   )
 
   expect_s3_class(as.mcmcr(analysis), "mcmcr")
 
   glance <- glance(analysis)
   expect_s3_class(glance, "tbl")
-  expect_identical(colnames(glance), c("n", "K", "nchains", "niters", "nthin", "ess", "rhat", "converged"))
+  expect_identical(
+    colnames(glance),
+    c("n", "K", "nchains", "niters", "nthin", "ess", "rhat", "converged")
+  )
   expect_identical(glance$n, 300L)
   expect_identical(glance$nthin, 1L)
   expect_identical(glance$K, 5L)
 
   derived <- coef(analysis, param_type = "derived", simplify = TRUE)
-  expect_identical(colnames(derived), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(derived),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
   expect_identical(nrow(derived), 300L)
 
   coef <- coef(analysis, simplify = TRUE)
 
   expect_s3_class(coef, "tbl")
-  expect_identical(colnames(coef), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(coef),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
 
-  expect_identical(coef$term, as.term(c(
-    "bHabitatQuality[1]", "bHabitatQuality[2]",
-    "bIntercept", "bYear",
-    "log_sDensity", "log_sSiteYear"
-  )))
+  expect_identical(
+    coef$term,
+    as.term(c(
+      "bHabitatQuality[1]",
+      "bHabitatQuality[2]",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    ))
+  )
 
   expect_identical(nrow(coef(analysis, "primary", simplify = TRUE)), 66L)
   expect_identical(nrow(coef(analysis, "all", simplify = TRUE)), 366L)
 
   tidy <- tidy(analysis)
-  expect_identical(colnames(tidy), c("term", "estimate", "lower", "upper", "esr", "rhat"))
+  expect_identical(
+    colnames(tidy),
+    c("term", "estimate", "lower", "upper", "esr", "rhat")
+  )
 
   year <- predict(analysis, new_data = "Year")
 
   ppc <- posterior_predictive_check(analysis)
 
   expect_s3_class(ppc, "tbl_df")
-  expect_identical(colnames(ppc), c("moment", "observed", "median", "lower", "upper", "svalue"))
-  expect_identical(ppc$moment, structure(1:5, .Label = c(
-    "zeros", "mean", "variance", "skewness",
-    "kurtosis"
-  ), class = "factor"))
+  expect_identical(
+    colnames(ppc),
+    c("moment", "observed", "median", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    ppc$moment,
+    structure(
+      1:5,
+      .Label = c(
+        "zeros",
+        "mean",
+        "variance",
+        "skewness",
+        "kurtosis"
+      ),
+      class = "factor"
+    )
+  )
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
-  dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
   expect_true(mcmcdata::is.mcmc_data(dd))
 
-  expect_warning(expect_warning(sensitivity <- sd_priors_by(analysis, by = 10, glance = FALSE)))
+  expect_warning(expect_warning(
+    sensitivity <- sd_priors_by(analysis, by = 10, glance = FALSE)
+  ))
   expect_snapshot_output(code(get_model(sensitivity)))
 })
 
@@ -191,17 +266,22 @@ test_that("analyse vectorized stand alone character", {
   model <- model(
     code = jags_template,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor")),
     new_expr = new_expr,
     new_expr_vec = TRUE
   )
 
-  expect_output(expect_warning(expect_warning(analysis <- analyse(model, data = data))))
+  expect_output(expect_warning(expect_warning(
+    analysis <- analyse(model, data = data)
+  )))
 
   expect_equal(as.data.frame(data_set(analysis)), data)
   data2 <- data_set(analysis, marginalize_random_effects = TRUE)
@@ -228,69 +308,137 @@ test_that("analyse vectorized stand alone character", {
   expect_identical(niters(analysis), 10L)
   expect_identical(ngens(analysis), 40L)
 
-
-  expect_identical(pars(analysis, "fixed"), sort(c("bHabitatQuality", "bIntercept", "bYear", "log_sDensity", "log_sSiteYear")))
+  expect_identical(
+    pars(analysis, "fixed"),
+    sort(c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    ))
+  )
   expect_identical(pars(analysis, "random"), "bSiteYear")
   expect_identical(pars(analysis, "derived"), "eDensity")
   expect_identical(
     pars(analysis, "primary"),
-    c("bHabitatQuality", "bIntercept", "bSiteYear", "bYear", "log_sDensity", "log_sSiteYear")
+    c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bSiteYear",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    )
   )
   expect_identical(
     pars(analysis),
-    c("bHabitatQuality", "bIntercept", "bSiteYear", "bYear", "eDensity", "log_sDensity", "log_sSiteYear")
+    c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bSiteYear",
+      "bYear",
+      "eDensity",
+      "log_sDensity",
+      "log_sSiteYear"
+    )
   )
 
   expect_s3_class(as.mcmcr(analysis), "mcmcr")
 
   glance <- glance(analysis)
   expect_s3_class(glance, "tbl")
-  expect_identical(colnames(glance), c("n", "K", "nchains", "niters", "nthin", "ess", "rhat", "converged"))
+  expect_identical(
+    colnames(glance),
+    c("n", "K", "nchains", "niters", "nthin", "ess", "rhat", "converged")
+  )
   expect_identical(glance$n, 300L)
   expect_identical(glance$nthin, 1L)
   expect_identical(glance$K, 5L)
 
   derived <- coef(analysis, param_type = "derived", simplify = TRUE)
-  expect_identical(colnames(derived), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(derived),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
   expect_identical(nrow(derived), 300L)
 
   coef <- coef(analysis, simplify = TRUE)
 
   expect_s3_class(coef, "tbl")
-  expect_identical(colnames(coef), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(coef),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
 
-  expect_identical(coef$term, as.term(c(
-    "bHabitatQuality[1]", "bHabitatQuality[2]",
-    "bIntercept", "bYear",
-    "log_sDensity", "log_sSiteYear"
-  )))
+  expect_identical(
+    coef$term,
+    as.term(c(
+      "bHabitatQuality[1]",
+      "bHabitatQuality[2]",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    ))
+  )
 
   expect_identical(nrow(coef(analysis, "primary", simplify = TRUE)), 66L)
   expect_identical(nrow(coef(analysis, "all", simplify = TRUE)), 366L)
 
   tidy <- tidy(analysis)
-  expect_identical(colnames(tidy), c("term", "estimate", "lower", "upper", "esr", "rhat"))
+  expect_identical(
+    colnames(tidy),
+    c("term", "estimate", "lower", "upper", "esr", "rhat")
+  )
 
   year <- predict(analysis, new_data = "Year")
 
   ppc <- posterior_predictive_check(analysis)
 
   expect_s3_class(ppc, "tbl_df")
-  expect_identical(colnames(ppc), c("moment", "observed", "median", "lower", "upper", "svalue"))
-  expect_identical(ppc$moment, structure(1:5, .Label = c(
-    "zeros", "mean", "variance", "skewness",
-    "kurtosis"
-  ), class = "factor"))
+  expect_identical(
+    colnames(ppc),
+    c("moment", "observed", "median", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    ppc$moment,
+    structure(
+      1:5,
+      .Label = c(
+        "zeros",
+        "mean",
+        "variance",
+        "skewness",
+        "kurtosis"
+      ),
+      class = "factor"
+    )
+  )
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
-  dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
   expect_true(mcmcdata::is.mcmc_data(dd))
 })
 
@@ -329,21 +477,29 @@ test_that("analyse vectorized embedded expression", {
   }
 }",
     new_expr = for (i in 1:length(Density)) {
-      fit[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
+      fit[i] <- bIntercept +
+        bYear * Year[i] +
+        bHabitatQuality[HabitatQuality[i]] +
+        bSiteYear[Site[i], YearFactor[i]]
       log(prediction[i]) <- fit[i]
       residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
     },
     new_expr_vec = TRUE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
-  expect_output(expect_warning(expect_warning(analysis <- analyse(model, data = data))))
+  expect_output(expect_warning(expect_warning(
+    analysis <- analyse(model, data = data)
+  )))
 
   expect_equal(as.data.frame(data_set(analysis)), data)
   data2 <- data_set(analysis, marginalize_random_effects = TRUE)
@@ -370,72 +526,142 @@ test_that("analyse vectorized embedded expression", {
   expect_identical(niters(analysis), 10L)
   expect_identical(ngens(analysis), 40L)
 
-
-  expect_identical(pars(analysis, "fixed"), sort(c("bHabitatQuality", "bIntercept", "bYear", "log_sDensity", "log_sSiteYear")))
+  expect_identical(
+    pars(analysis, "fixed"),
+    sort(c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    ))
+  )
   expect_identical(pars(analysis, "random"), "bSiteYear")
   expect_identical(pars(analysis, "derived"), "eDensity")
   expect_identical(
     pars(analysis, "primary"),
-    c("bHabitatQuality", "bIntercept", "bSiteYear", "bYear", "log_sDensity", "log_sSiteYear")
+    c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bSiteYear",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    )
   )
   expect_identical(
     pars(analysis),
-    c("bHabitatQuality", "bIntercept", "bSiteYear", "bYear", "eDensity", "log_sDensity", "log_sSiteYear")
+    c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bSiteYear",
+      "bYear",
+      "eDensity",
+      "log_sDensity",
+      "log_sSiteYear"
+    )
   )
 
   expect_s3_class(as.mcmcr(analysis), "mcmcr")
 
   glance <- glance(analysis)
   expect_s3_class(glance, "tbl")
-  expect_identical(colnames(glance), c("n", "K", "nchains", "niters", "nthin", "ess", "rhat", "converged"))
+  expect_identical(
+    colnames(glance),
+    c("n", "K", "nchains", "niters", "nthin", "ess", "rhat", "converged")
+  )
   expect_identical(glance$n, 300L)
   expect_identical(glance$nthin, 1L)
   expect_identical(glance$K, 5L)
 
   derived <- coef(analysis, param_type = "derived", simplify = TRUE)
-  expect_identical(colnames(derived), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(derived),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
   expect_identical(nrow(derived), 300L)
 
   coef <- coef(analysis, simplify = TRUE)
 
   expect_s3_class(coef, "tbl")
-  expect_identical(colnames(coef), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(coef),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
 
-  expect_identical(coef$term, as.term(c(
-    "bHabitatQuality[1]", "bHabitatQuality[2]",
-    "bIntercept", "bYear",
-    "log_sDensity", "log_sSiteYear"
-  )))
+  expect_identical(
+    coef$term,
+    as.term(c(
+      "bHabitatQuality[1]",
+      "bHabitatQuality[2]",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    ))
+  )
 
   expect_identical(nrow(coef(analysis, "primary", simplify = TRUE)), 66L)
   expect_identical(nrow(coef(analysis, "all", simplify = TRUE)), 366L)
 
   tidy <- tidy(analysis)
-  expect_identical(colnames(tidy), c("term", "estimate", "lower", "upper", "esr", "rhat"))
+  expect_identical(
+    colnames(tidy),
+    c("term", "estimate", "lower", "upper", "esr", "rhat")
+  )
 
   year <- predict(analysis, new_data = "Year")
 
   ppc <- posterior_predictive_check(analysis)
 
   expect_s3_class(ppc, "tbl_df")
-  expect_identical(colnames(ppc), c("moment", "observed", "median", "lower", "upper", "svalue"))
-  expect_identical(ppc$moment, structure(1:5, .Label = c(
-    "zeros", "mean", "variance", "skewness",
-    "kurtosis"
-  ), class = "factor"))
+  expect_identical(
+    colnames(ppc),
+    c("moment", "observed", "median", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    ppc$moment,
+    structure(
+      1:5,
+      .Label = c(
+        "zeros",
+        "mean",
+        "variance",
+        "skewness",
+        "kurtosis"
+      ),
+      class = "factor"
+    )
+  )
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
-  dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
   expect_true(mcmcdata::is.mcmc_data(dd))
 
-  expect_warning(expect_warning(sensitivity <- sd_priors_by(analysis, by = 10, glance = FALSE)))
+  expect_warning(expect_warning(
+    sensitivity <- sd_priors_by(analysis, by = 10, glance = FALSE)
+  ))
   expect_snapshot_output(code(get_model(sensitivity)))
 
   analyses <- analyses(analysis, sensitivity)
@@ -444,7 +670,19 @@ test_that("analyse vectorized embedded expression", {
 
   expect_s3_class(glance, "tbl")
   expect_identical(nrow(glance), 1L)
-  expect_identical(colnames(glance), c("n", "K", "nchains", "niters", "rhat_1", "rhat_2", "rhat_all", "converged"))
+  expect_identical(
+    colnames(glance),
+    c(
+      "n",
+      "K",
+      "nchains",
+      "niters",
+      "rhat_1",
+      "rhat_2",
+      "rhat_all",
+      "converged"
+    )
+  )
 })
 
 test_that("analyse vectorized embedded nested expression", {
@@ -483,22 +721,30 @@ test_that("analyse vectorized embedded nested expression", {
 }",
     new_expr = {
       for (i in 1:length(Density)) {
-        fit[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
+        fit[i] <- bIntercept +
+          bYear * Year[i] +
+          bHabitatQuality[HabitatQuality[i]] +
+          bSiteYear[Site[i], YearFactor[i]]
         log(prediction[i]) <- fit[i]
         residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
       }
     },
     new_expr_vec = TRUE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
-  expect_output(expect_warning(expect_warning(analysis <- analyse(model, data = data))))
+  expect_output(expect_warning(expect_warning(
+    analysis <- analyse(model, data = data)
+  )))
 
   expect_equal(as.data.frame(data_set(analysis)), data)
   data2 <- data_set(analysis, marginalize_random_effects = TRUE)
@@ -517,71 +763,142 @@ test_that("analyse vectorized embedded nested expression", {
   expect_identical(niters(analysis), 10L)
   expect_identical(ngens(analysis), 40L)
 
-  expect_identical(pars(analysis, "fixed"), sort(c("bHabitatQuality", "bIntercept", "bYear", "log_sDensity", "log_sSiteYear")))
+  expect_identical(
+    pars(analysis, "fixed"),
+    sort(c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    ))
+  )
   expect_identical(pars(analysis, "random"), "bSiteYear")
   expect_identical(pars(analysis, "derived"), "eDensity")
   expect_identical(
     pars(analysis, "primary"),
-    c("bHabitatQuality", "bIntercept", "bSiteYear", "bYear", "log_sDensity", "log_sSiteYear")
+    c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bSiteYear",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    )
   )
   expect_identical(
     pars(analysis),
-    c("bHabitatQuality", "bIntercept", "bSiteYear", "bYear", "eDensity", "log_sDensity", "log_sSiteYear")
+    c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bSiteYear",
+      "bYear",
+      "eDensity",
+      "log_sDensity",
+      "log_sSiteYear"
+    )
   )
 
   expect_s3_class(as.mcmcr(analysis), "mcmcr")
 
   glance <- glance(analysis)
   expect_s3_class(glance, "tbl")
-  expect_identical(colnames(glance), c("n", "K", "nchains", "niters", "nthin", "ess", "rhat", "converged"))
+  expect_identical(
+    colnames(glance),
+    c("n", "K", "nchains", "niters", "nthin", "ess", "rhat", "converged")
+  )
   expect_identical(glance$n, 300L)
   expect_identical(glance$nthin, 1L)
   expect_identical(glance$K, 5L)
 
   derived <- coef(analysis, param_type = "derived", simplify = TRUE)
-  expect_identical(colnames(derived), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(derived),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
   expect_identical(nrow(derived), 300L)
 
   coef <- coef(analysis, simplify = TRUE)
 
   expect_s3_class(coef, "tbl")
-  expect_identical(colnames(coef), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(coef),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
 
-  expect_identical(coef$term, as.term(c(
-    "bHabitatQuality[1]", "bHabitatQuality[2]",
-    "bIntercept", "bYear",
-    "log_sDensity", "log_sSiteYear"
-  )))
+  expect_identical(
+    coef$term,
+    as.term(c(
+      "bHabitatQuality[1]",
+      "bHabitatQuality[2]",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    ))
+  )
 
   expect_identical(nrow(coef(analysis, "primary", simplify = TRUE)), 66L)
   expect_identical(nrow(coef(analysis, "all", simplify = TRUE)), 366L)
 
   tidy <- tidy(analysis)
-  expect_identical(colnames(tidy), c("term", "estimate", "lower", "upper", "esr", "rhat"))
+  expect_identical(
+    colnames(tidy),
+    c("term", "estimate", "lower", "upper", "esr", "rhat")
+  )
 
   year <- predict(analysis, new_data = "Year")
 
   ppc <- posterior_predictive_check(analysis)
 
   expect_s3_class(ppc, "tbl_df")
-  expect_identical(colnames(ppc), c("moment", "observed", "median", "lower", "upper", "svalue"))
-  expect_identical(ppc$moment, structure(1:5, .Label = c(
-    "zeros", "mean", "variance", "skewness",
-    "kurtosis"
-  ), class = "factor"))
+  expect_identical(
+    colnames(ppc),
+    c("moment", "observed", "median", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    ppc$moment,
+    structure(
+      1:5,
+      .Label = c(
+        "zeros",
+        "mean",
+        "variance",
+        "skewness",
+        "kurtosis"
+      ),
+      class = "factor"
+    )
+  )
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
-  dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
   expect_true(mcmcdata::is.mcmc_data(dd))
 
-  expect_warning(expect_warning(sensitivity <- sd_priors_by(analysis, by = 10, glance = FALSE)))
+  expect_warning(expect_warning(
+    sensitivity <- sd_priors_by(analysis, by = 10, glance = FALSE)
+  ))
   expect_snapshot_output(code(get_model(sensitivity)))
 
   analyses <- analyses(analysis, sensitivity)
@@ -590,7 +907,19 @@ test_that("analyse vectorized embedded nested expression", {
 
   expect_s3_class(glance, "tbl")
   expect_identical(nrow(glance), 1L)
-  expect_identical(colnames(glance), c("n", "K", "nchains", "niters", "rhat_1", "rhat_2", "rhat_all", "converged"))
+  expect_identical(
+    colnames(glance),
+    c(
+      "n",
+      "K",
+      "nchains",
+      "niters",
+      "rhat_1",
+      "rhat_2",
+      "rhat_all",
+      "converged"
+    )
+  )
 })
 
 test_that("analyse full nimble notation vectorized embedded nested expression", {
@@ -622,28 +951,39 @@ test_that("analyse full nimble notation vectorized embedded nested expression", 
       }
 
       for (i in 1:length(Density)) {
-        eDensity[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
+        eDensity[i] <- bIntercept +
+          bYear * Year[i] +
+          bHabitatQuality[HabitatQuality[i]] +
+          bSiteYear[Site[i], YearFactor[i]]
         Density[i] ~ dlnorm(eDensity[i], sd = sDensity)
       }
     },
     new_expr = {
       for (i in 1:length(Density)) {
-        fit[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
+        fit[i] <- bIntercept +
+          bYear * Year[i] +
+          bHabitatQuality[HabitatQuality[i]] +
+          bSiteYear[Site[i], YearFactor[i]]
         log(prediction[i]) <- fit[i]
         residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
       }
     },
     new_expr_vec = TRUE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
-  expect_output(expect_warning(expect_warning(analysis <- analyse(model, data = data, engine = "jags"))))
+  expect_output(expect_warning(expect_warning(
+    analysis <- analyse(model, data = data, engine = "jags")
+  )))
 
   expect_equal(as.data.frame(data_set(analysis)), data)
   data2 <- data_set(analysis, marginalize_random_effects = TRUE)
@@ -662,71 +1002,143 @@ test_that("analyse full nimble notation vectorized embedded nested expression", 
   expect_identical(niters(analysis), 10L)
   expect_identical(ngens(analysis), 40L)
 
-  expect_identical(pars(analysis, "fixed"), sort(c("bHabitatQuality", "bIntercept", "bYear", "log_sDensity", "log_sSiteYear")))
+  expect_identical(
+    pars(analysis, "fixed"),
+    sort(c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    ))
+  )
   expect_identical(pars(analysis, "random"), "bSiteYear")
   expect_identical(pars(analysis, "derived"), "eDensity")
   expect_identical(
     pars(analysis, "primary"),
-    c("bHabitatQuality", "bIntercept", "bSiteYear", "bYear", "log_sDensity", "log_sSiteYear")
+    c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bSiteYear",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    )
   )
   expect_identical(
     pars(analysis),
-    c("bHabitatQuality", "bIntercept", "bSiteYear", "bYear", "eDensity", "log_sDensity", "log_sSiteYear")
+    c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bSiteYear",
+      "bYear",
+      "eDensity",
+      "log_sDensity",
+      "log_sSiteYear"
+    )
   )
 
   expect_s3_class(as.mcmcr(analysis), "mcmcr")
 
   glance <- glance(analysis)
   expect_s3_class(glance, "tbl")
-  expect_identical(colnames(glance), c("n", "K", "nchains", "niters", "nthin", "ess", "rhat", "converged"))
+  expect_identical(
+    colnames(glance),
+    c("n", "K", "nchains", "niters", "nthin", "ess", "rhat", "converged")
+  )
   expect_identical(glance$n, 300L)
   expect_identical(glance$nthin, 1L)
   expect_identical(glance$K, 5L)
 
   derived <- coef(analysis, param_type = "derived", simplify = TRUE)
-  expect_identical(colnames(derived), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(derived),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
   expect_identical(nrow(derived), 300L)
 
   coef <- coef(analysis, simplify = TRUE)
 
   expect_s3_class(coef, "tbl")
-  expect_identical(colnames(coef), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(coef),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
 
-  expect_identical(coef$term, as.term(c(
-    "bHabitatQuality[1]", "bHabitatQuality[2]",
-    "bIntercept", "bYear",
-    "log_sDensity", "log_sSiteYear"
-  )))
+  expect_identical(
+    coef$term,
+    as.term(c(
+      "bHabitatQuality[1]",
+      "bHabitatQuality[2]",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    ))
+  )
 
   expect_identical(nrow(coef(analysis, "primary", simplify = TRUE)), 66L)
   expect_identical(nrow(coef(analysis, "all", simplify = TRUE)), 366L)
 
   tidy <- tidy(analysis)
-  expect_identical(colnames(tidy), c("term", "estimate", "lower", "upper", "esr", "rhat"))
+  expect_identical(
+    colnames(tidy),
+    c("term", "estimate", "lower", "upper", "esr", "rhat")
+  )
 
   year <- predict(analysis, new_data = "Year")
 
   ppc <- posterior_predictive_check(analysis)
 
   expect_s3_class(ppc, "tbl_df")
-  expect_identical(colnames(ppc), c("moment", "observed", "median", "lower", "upper", "svalue"))
-  expect_identical(ppc$moment, structure(1:5, .Label = c(
-    "zeros", "mean", "variance", "skewness",
-    "kurtosis"
-  ), class = "factor"))
+  expect_identical(
+    colnames(ppc),
+    c("moment", "observed", "median", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    ppc$moment,
+    structure(
+      1:5,
+      .Label = c(
+        "zeros",
+        "mean",
+        "variance",
+        "skewness",
+        "kurtosis"
+      ),
+      class = "factor"
+    )
+  )
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
-  dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
   expect_true(mcmcdata::is.mcmc_data(dd))
 
-  expect_warning(expect_warning(sensitivity <- sd_priors_by(analysis, by = 10, glance = FALSE), "incomplete adaptation"))
+  expect_warning(expect_warning(
+    sensitivity <- sd_priors_by(analysis, by = 10, glance = FALSE),
+    "incomplete adaptation"
+  ))
   expect_snapshot_output(code(get_model(sensitivity)))
 
   analyses <- analyses(analysis, sensitivity)
@@ -735,5 +1147,17 @@ test_that("analyse full nimble notation vectorized embedded nested expression", 
 
   expect_s3_class(glance, "tbl")
   expect_identical(nrow(glance), 1L)
-  expect_identical(colnames(glance), c("n", "K", "nchains", "niters", "rhat_1", "rhat_2", "rhat_all", "converged"))
+  expect_identical(
+    colnames(glance),
+    c(
+      "n",
+      "K",
+      "nchains",
+      "niters",
+      "rhat_1",
+      "rhat_2",
+      "rhat_all",
+      "converged"
+    )
+  )
 })


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)