### PR TITLE
Update vignette for defunct coef(simplify = FALSE)

### DIFF
--- a/vignettes/jmbr.Rmd
+++ b/vignettes/jmbr.Rmd
@@ -223,18 +223,12 @@ __Coefficient Table__
 
 Summary table of the posterior probability distribution.
 ```{r, message = FALSE}
-coef(analysis)
+coef(analysis, directional_information = FALSE)
 ```
 
 The estimate is the __median__ by default.
 
-The zscore is $mean / sd$.
-
-```{r}
-coef(analysis, simplify = TRUE)
-```
-
-The s-value is the __suprisal__ value, which is a measure of directionality with respect to zero. 
+The s-value is the __suprisal__ value, which is a measure of directionality with respect to zero.
 
 The s-value is zero (unsurprising) when _p-value_ = 1.0 and increases exponentially as _p_ approaches zero.  
 


### PR DESCRIPTION
R-CMD-check and pkgdown have failed since July 11 because poissonconsulting/mcmcr#74 made `coef(simplify = FALSE)` defunct, and the vignette's default `coef(analysis)` call reached it via `embr:::coef.mb_analysis()`.

This PR updates the coefficient-table section of the vignette to a single `coef(analysis, directional_information = FALSE)` call (explicit to avoid the soft deprecation warning about the changing `directional_information` default) and drops the now-obsolete zscore prose.

Depends on poissonconsulting/embr#120 (default `simplify = TRUE` in embr) being merged and published to r-universe before CI here can pass. Verified locally by knitting the vignette against current r-universe binaries plus the embr branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)